### PR TITLE
css-stylelint: Pass stdin-filename to avoid language guessing

### DIFF
--- a/flycheck.el
+++ b/flycheck.el
@@ -7303,7 +7303,8 @@ See URL `http://stylelint.io/'."
   :command ("stylelint"
             (eval flycheck-stylelint-args)
             (option-flag "--quiet" flycheck-stylelint-quiet)
-            (config-file "--config" flycheck-stylelintrc))
+            (config-file "--config" flycheck-stylelintrc)
+            "--stdin-filename" (eval (or (buffer-file-name) "style.css")))
   :standard-input t
   :error-parser flycheck-parse-stylelint
   :modes (css-mode))


### PR DESCRIPTION
When passed a file from stdin, stylelint tries to guess what language the file
is written in, and sometimes it's not the language we intended. For example,
here's a fun stylesheet which got recognised as html:

```css
.foo {
    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="hsl(218, 46%, 34%)">...</svg>');
}
```

The inline svg caused stylelint to guess, given no other info, that this was an
html document, and there's no css here to lint. This commit passes the current
buffer's filename to stylelint, helping it in its noble cause.
